### PR TITLE
Experimentalni parser pro Moravskoslezsky kraj

### DIFF
--- a/crawl.py
+++ b/crawl.py
@@ -13,6 +13,7 @@ from libs import kraj_strc
 from libs import kraj_pha
 from libs import kraj_brn
 from libs import kraj_zl
+from libs import kraj_msk
 
 import pygsheets
 import pandas as pd
@@ -43,6 +44,7 @@ kraje = [
   kraj_pha.web().crawl(),
   kraj_brn.web().crawl(),
   kraj_zl.web().crawl(),
+  kraj_msk..web().crawl(),
   
   ]
 

--- a/libs/kraj_msk.py
+++ b/libs/kraj_msk.py
@@ -1,0 +1,56 @@
+from . import utils
+
+from pytesseract import image_to_string
+import pytesseract
+from PIL import Image
+from urllib.parse import urljoin
+
+class web:
+  kraj = 'Moravskoslezský kraj'
+
+  def crawl(self):
+    khs_url = 'http://www.khsova.cz/homepage/korona-statistika'
+
+    html = utils.get_url(khs_url)
+    img_url = urljoin(khs_url, html.select_one('.inner img:nth-of-type(2)')['src'])
+    img = utils.get_img(img_url)
+
+    first_row_offset = 110
+    column_offset = 138
+    row_spacing = 48.5
+    number_height = 14
+    target_color = img.getpixel((column_offset, first_row_offset))
+    gray = (204, 204, 204, 255)
+    white = (255, 255, 255, 255)
+    okresy = [
+      'Bruntál',
+      'Frýdek-Místek',
+      'Karviná',
+      'Nový Jičín',
+      'Opava',
+      'Ostrava'
+    ]
+
+    cropped_imgs = []
+    for row_index in range(0, 6):
+      y = int(first_row_offset + row_spacing * row_index) - row_index
+      px = img.getpixel((column_offset, y))
+      x = column_offset
+      while px == target_color:
+        px = img.getpixel((x, y))
+        x += 1
+      x = x + 5
+      cropped_imgs.append(
+        img.crop((x, y, x+img.width, y+number_height)))
+
+    results = []
+    for index, cropped_img in enumerate(cropped_imgs):
+      for x in range(0, cropped_img.width):
+        for y in range(0, cropped_img.height):
+          px = cropped_img.getpixel((x, y))
+          if px == gray:
+            cropped_img.putpixel((x, y), white)
+      val = int(image_to_string(cropped_img))
+      results.append(
+        {'okres': okresy[index], 'kraj': self.kraj, 'hodnota': val})
+    return results


### PR DESCRIPTION
Ahoj, zkusil jsem v grafu od khsova.cz hledat konec toho barevneho *sloupce* (jak se to sakra jmenuje, kdyz je graf horizontalne? :D) a v prostoru vpravo za nim cislo.

Takhle nejak:

![chickadee_20200330_225846](https://user-images.githubusercontent.com/178133/77961428-53508400-72c9-11ea-91a0-4e6c2cea410e.png)

Po rozrezani smazu ty sedive cary a predhodim to Tesseractu. Funguje to docela dobre, ale zatim to mam vyzkousene jen na `koronavirus_statistika_pocet_pripadu-20200327.png`, coz je podle nazvu souboru i HTTP hlavicek z patku… Novejsi na webu zatim nemaji a ja zas bohuzel nemam starsi, abych vyzkousel jak  spolehlive to je. Budu to sledovat a pripadne doladim…

```
[
    {'okres': 'Bruntál', 'kraj': 'Moravskoslezský kraj', 'hodnota': 19},
    {'okres': 'Frýdek-Místek', 'kraj': 'Moravskoslezský kraj', 'hodnota': 64},
    {'okres': 'Karviná', 'kraj': 'Moravskoslezský kraj', 'hodnota': 33},
    {'okres': 'Nový Jičín', 'kraj': 'Moravskoslezský kraj', 'hodnota': 19},
    {'okres': 'Opava', 'kraj': 'Moravskoslezský kraj', 'hodnota': 25},
    {'okres': 'Ostrava', 'kraj': 'Moravskoslezský kraj', 'hodnota': 46}
]
```
