### PR TITLE
Pridani chybejici uvozovky u Ostravy

### DIFF
--- a/libs/kraj_msk.py
+++ b/libs/kraj_msk.py
@@ -38,7 +38,7 @@ class web:
         'Opava',
         'Vítkov',
       ],
-      'Ostrava: [
+      'Ostrava': [
         'Ostrava',
       ]
     }


### PR DESCRIPTION
Pri prejmenovani Ostravy–mesto na Ostravu to odnesla i zaviraci uvozovka stringu: 2c24eb45b4e42873148726a0e77f932521c5737f