### PR TITLE
Plzensky kraj – oprava OCR

### DIFF
--- a/libs/kraj_plz.py
+++ b/libs/kraj_plz.py
@@ -22,24 +22,24 @@ class web:
     results=[]
     img = utils.get_img('http://www.khsplzen.cz/images/KHS/covid19/Plzensky_kraj.jpg')
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,297,288)), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,297,288), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Plzeň-město', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,102,235)), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,102,235), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Tachov', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,268,190)), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,268,190), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Plzeň-sever', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,381,260)), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,381,260), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Rokycany', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,124,373)), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,124,373), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Domažlice', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,328,370)), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,328,370), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Plzeň-jih', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,268,494)), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,268,494), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Klatovy', 'kraj': self.kraj, 'hodnota':val})
     return results

--- a/libs/kraj_plz.py
+++ b/libs/kraj_plz.py
@@ -8,38 +8,38 @@ class web:
 
   kraj= "Plzeňský kraj"
   
-  def imgcrop(self,img,x,y,w=44,h=32):
-    return img.crop((x,y,x+w,y+h))  
-  
-  def num_trick(self,img):
-    num_img = Image.open('./files/number.jpg')
-    new_img = Image.new('RGB', (144, 32))
-    new_img.paste(num_img, (0,0))
-    new_img.paste(img, (100,0))
-    return new_img
+  def imgcrop(self,img,x,y,w=50,h=35):
+    cropped = img.crop((x,y,x+w,y+h)).convert('LA')
+    for px_x in range(0, w):
+      for px_y in range(0, h):
+        px = cropped.getpixel((px_x, px_y))
+        if px > (200, 255):
+          cropped.putpixel((px_x, px_y), (255, 255))
+    return cropped
   
   def crawl(self):
     results=[]
     img = utils.get_img('http://www.khsplzen.cz/images/KHS/covid19/Plzensky_kraj.jpg')
     
-    val = image_to_string(self.imgcrop(img,297,288), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,294,285), config='digits')
     results.append({ 'okres':'Plzeň-město', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,102,235), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,100,234), config='digits')
     results.append({ 'okres':'Tachov', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,268,190), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,262,187), config='digits')
     results.append({ 'okres':'Plzeň-sever', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,381,260), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,375,257), config='digits')
     results.append({ 'okres':'Rokycany', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,124,373), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,118,370), config='digits')
     results.append({ 'okres':'Domažlice', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,328,370), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,322,368), config='digits')
     results.append({ 'okres':'Plzeň-jih', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,268,494), config='digits').replace('number','').replace(' ','')
+    val = image_to_string(self.imgcrop(img,265,492), config='digits')
     results.append({ 'okres':'Klatovy', 'kraj': self.kraj, 'hodnota':val})
+
     return results

--- a/libs/kraj_plz.py
+++ b/libs/kraj_plz.py
@@ -13,33 +13,37 @@ class web:
     for px_x in range(0, w):
       for px_y in range(0, h):
         px = cropped.getpixel((px_x, px_y))
-        if px > (200, 255):
+        if px > (100, 255):
           cropped.putpixel((px_x, px_y), (255, 255))
+        if px < (100, 255):
+          cropped.putpixel((px_x, px_y), (0, 255))
+    cropped = cropped.resize([int(2 * s) for s in cropped.size], Image.NEAREST)
     return cropped
   
   def crawl(self):
+    tsconfig='--psm 7 digits'
     results=[]
     img = utils.get_img('http://www.khsplzen.cz/images/KHS/covid19/Plzensky_kraj.jpg')
     
-    val = image_to_string(self.imgcrop(img,294,285), config='digits')
+    val = int(image_to_string(self.imgcrop(img,294,285), config=tsconfig))
     results.append({ 'okres':'Plzeň-město', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,100,234), config='digits')
+    val = int(image_to_string(self.imgcrop(img,100,234), config=tsconfig))
     results.append({ 'okres':'Tachov', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,262,187), config='digits')
+    val = int(image_to_string(self.imgcrop(img,262,187), config=tsconfig))
     results.append({ 'okres':'Plzeň-sever', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,375,257), config='digits')
+    val = int(image_to_string(self.imgcrop(img,375,257), config=tsconfig))
     results.append({ 'okres':'Rokycany', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,118,370), config='digits')
+    val = int(image_to_string(self.imgcrop(img,118,370), config=tsconfig))
     results.append({ 'okres':'Domažlice', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,322,368), config='digits')
+    val = int(image_to_string(self.imgcrop(img,322,368), config=tsconfig))
     results.append({ 'okres':'Plzeň-jih', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.imgcrop(img,265,492), config='digits')
+    val = int(image_to_string(self.imgcrop(img,265,492), config=tsconfig))
     results.append({ 'okres':'Klatovy', 'kraj': self.kraj, 'hodnota':val})
 
     return results

--- a/libs/kraj_plz.py
+++ b/libs/kraj_plz.py
@@ -22,24 +22,24 @@ class web:
     results=[]
     img = utils.get_img('http://www.khsplzen.cz/images/KHS/covid19/Plzensky_kraj.jpg')
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,297,288))).replace('number','').replace(' ','')
+    val = image_to_string(self.num_trick(self.imgcrop(img,297,288)), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Plzeň-město', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,102,235))).replace('number','').replace(' ','')
+    val = image_to_string(self.num_trick(self.imgcrop(img,102,235)), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Tachov', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,268,190))).replace('number','').replace(' ','')
+    val = image_to_string(self.num_trick(self.imgcrop(img,268,190)), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Plzeň-sever', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,381,260))).replace('number','').replace(' ','')
+    val = image_to_string(self.num_trick(self.imgcrop(img,381,260)), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Rokycany', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,124,373))).replace('number','').replace(' ','')
+    val = image_to_string(self.num_trick(self.imgcrop(img,124,373)), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Domažlice', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,328,370))).replace('number','').replace(' ','')
+    val = image_to_string(self.num_trick(self.imgcrop(img,328,370)), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Plzeň-jih', 'kraj': self.kraj, 'hodnota':val})
     
-    val = image_to_string(self.num_trick(self.imgcrop(img,268,494))).replace('number','').replace(' ','')
+    val = image_to_string(self.num_trick(self.imgcrop(img,268,494)), config='digits').replace('number','').replace(' ','')
     results.append({ 'okres':'Klatovy', 'kraj': self.kraj, 'hodnota':val})
     return results


### PR DESCRIPTION
Oprava #7 

- odstraneni JPEG artefaktu z prostoru kolem cislic
- uprava souradnic a rozmeru, aby se do oriznute casti veslo trojciferne cislo (Domazlice uz maji pres sto…)
- prevod na 2bit barvy a zvetseni, Tesseractu se to zda se libi vic
- parametry pro Tesseract: `digits` (hledat jen cislice) a `psm=7` (hledat jen jeden radek textu)
- odstraneni num_trick, uz nebyl potreba a Tesseractem 3.x byl po tech upravach spis na skodu
- zkouseno s Tesseract 3.05.02 a 4.1.1

```
{'okres': 'Plzeň-město', 'kraj': 'Plzeňský kraj', 'hodnota': 37},
{'okres': 'Tachov', 'kraj': 'Plzeňský kraj', 'hodnota': 14},
{'okres': 'Plzeň-sever', 'kraj': 'Plzeňský kraj', 'hodnota': 10},
{'okres': 'Rokycany', 'kraj': 'Plzeňský kraj', 'hodnota': 2},
{'okres': 'Domažlice', 'kraj': 'Plzeňský kraj', 'hodnota': 114},
{'okres': 'Plzeň-jih', 'kraj': 'Plzeňský kraj', 'hodnota': 13},
{'okres': 'Klatovy', 'kraj': 'Plzeňský kraj', 'hodnota': 15}
```

![covid-pk](https://user-images.githubusercontent.com/178133/78413640-e2320900-7607-11ea-9cdb-54e180b60f91.jpg)
