### PR TITLE
Ústecký kraj: oprava parsování po změně struktury PDF

### DIFF
--- a/libs/kraj_usti.py
+++ b/libs/kraj_usti.py
@@ -1,34 +1,27 @@
 from . import utils
 
-#TODO: rozdělit na crawl a mapping
-
 class web:
+  kraj= 'Ústecký kraj'
 
-  kraj= "Ústecký kraj"
-  
   def crawl(self):
+    url = 'http://www.khsusti.cz/php/kousky/covid19/pocet_testovanych_osob_na_covid19_ustecky_kraj.pdf'
+    pocet_okresu = 7
     results=[]
-    lines = utils.get_pdfminer('http://www.khsusti.cz/php/kousky/covid19/pocet_testovanych_osob_na_covid19_ustecky_kraj.pdf')
-    i=-17
-    for l in lines:
-        i=i+1
-        if i<10:
-            continue
-        if 'Děčín' in l:
-            results.append({ 'okres':'Děčín', 'kraj': self.kraj, 'hodnota':lines[i].strip()})
-        if 'Chomutov' in l:
-            results.append({ 'okres':'Chomutov', 'kraj': self.kraj, 'hodnota':lines[i].strip()})
-        if 'Most' in l:
-            results.append({ 'okres':'Most', 'kraj': self.kraj, 'hodnota':lines[i].strip()})
-        if 'Litoměřice' in l:
-            results.append({ 'okres':'Litoměřice', 'kraj': self.kraj, 'hodnota':lines[i].strip()})
-        if 'Louny' in l:
-            results.append({ 'okres':'Louny', 'kraj': self.kraj, 'hodnota':lines[i].strip()} )
-        if 'Teplice' in l:
-            results.append({ 'okres':'Teplice', 'kraj': self.kraj, 'hodnota':lines[i].strip()})
-        if 'Ústí nad Labem' in l:
-            results.append({ 'okres':'Ústí nad Labem', 'kraj': self.kraj, 'hodnota':lines[i].strip()})
-        
+    lines = [line for line in utils.get_pdfminer(url) if len(line.replace(' ', '')) > 0]
+    start_index = None
+    distance_to_counts = None
+    for i, line in enumerate(lines):
+        if line.startswith('okres'):
+            start_index = i + 1
+            for next_i in range(start_index, len(lines) - i):
+                if (lines[next_i][0].isdigit()):
+                    distance_to_counts = next_i - i - 1
+                    break
+            break
+    if start_index and distance_to_counts:
+        for i in range(start_index, start_index + pocet_okresu):
+            name = lines[i].strip().replace('D ín', 'Děčín').replace('Litom ice', 'Litoměřice')
+            results.append({'okres': name, 'kraj': self.kraj, 'hodnota': int(lines[i + distance_to_counts].strip())})
 
     return results
 


### PR DESCRIPTION
Oprava #10, s trochu jinym zpusobem hledani indexu prvniho okresu.

Ale nevim jak dlouho to vydrzi, PDF je na tohle fakt blbej format. Mozna by bylo spolehlivejsi prevest ho na obrazek a pouzit OCR…

```
[
{'okres': 'Děčín', 'kraj': 'Ústecký kraj', 'hodnota': 36},
{'okres': 'Chomutov', 'kraj': 'Ústecký kraj', 'hodnota': 12},
{'okres': 'Most', 'kraj': 'Ústecký kraj', 'hodnota': 15},
{'okres': 'Litoměřice', 'kraj': 'Ústecký kraj', 'hodnota': 114},
{'okres': 'Louny', 'kraj': 'Ústecký kraj', 'hodnota': 10},
{'okres': 'Teplice', 'kraj': 'Ústecký kraj', 'hodnota': 16},
{'okres': 'Ústí nad Labem', 'kraj': 'Ústecký kraj', 'hodnota': 62}
]
```

![chickadee_20200405_142500](https://user-images.githubusercontent.com/178133/78492787-8024f100-7738-11ea-889c-c670c922fc17.png)
