### PR TITLE
Zlínský kraj: oprava parsování PDF

### DIFF
--- a/libs/kraj_zl.py
+++ b/libs/kraj_zl.py
@@ -7,9 +7,10 @@ class web:
   def crawl(self):
     results = []
     pocet_okresu = 4
-    page = utils.get_url('http://www.khszlin.cz/25304-novy-koronavirus-2019-ncov')
+    url = 'http://www.khszlin.cz/25304-novy-koronavirus-2019-ncov'
+    page = utils.get_url(url)
     doc = page.select_one('a.pdf[href*=info_cov19]')['href']
-    url = urljoin('http://www.khszlin.cz/', doc)
+    url = urljoin(url, doc)
     lines = [line for line in utils.get_pdfminer(url) if len(line.replace(' ', '')) > 0]
     start_index = None
     distance_to_counts = None


### PR DESCRIPTION
Oprava #9. Stejny princip jako u Usti (#11).

```
[
{'okres': 'Kroměříž', 'kraj': 'Zlínský kraj', 'hodnota': 21},
{'okres': 'Uherské Hradiště', 'kraj': 'Zlínský kraj', 'hodnota': 104},
{'okres': 'Vsetín', 'kraj': 'Zlínský kraj', 'hodnota': 27},
{'okres': 'Zlín', 'kraj': 'Zlínský kraj', 'hodnota': 40}
]
```

![chickadee_20200405_145256](https://user-images.githubusercontent.com/178133/78498847-65547b80-773c-11ea-9b8e-5eba8090bb19.png)
