### PR TITLE
Praha: oprava hledání čísla ve stránce

### DIFF
--- a/libs/kraj_pha.py
+++ b/libs/kraj_pha.py
@@ -2,20 +2,14 @@ from . import utils
 import re
 
 class web:
-
   kraj= "Praha"
   
   def crawl(self):
     results=[]
     soup = utils.get_url('http://www.hygpraha.cz/obsah/koronavirus_506_1.html')
-    links = soup.select('.content .vypis-item h3 a')
-    for a in links:
-        search = re.search('V Praze (\d+).*hodin', a.text)
-        if search:
-          val = search.groups()[0]
-          results.append({ 'okres':'Praha', 'kraj': self.kraj,  'hodnota':val})
-          break
-        
-
+    link = soup.select_one('.content .vypis-item h3 a')
+    search = re.search('V Praze ([\d ]+).*hodin', link.text)
+    if search:
+      val = int(search.groups()[0].replace(" ", "").strip())
+      results.append({'okres':'Praha', 'kraj': self.kraj, 'hodnota': val})        
     return results
-


### PR DESCRIPTION
Problém byl v tom, že v posledním článku oddělili tisícovku mezerou (`1 132`, dříve to bylo bez mezery – `1045` atd.). Původní regexp bral jen tu jedničku před mezerou.

`[{'okres': 'Praha', 'kraj': 'Praha', 'hodnota': 1132}]`

![chickadee_20200407_141743](https://user-images.githubusercontent.com/178133/78668319-01f85400-78ca-11ea-90f5-01b3413dba54.png)
